### PR TITLE
Add BaseTestClass & set as a dependency.

### DIFF
--- a/test/tests/AmazonSESTest.php
+++ b/test/tests/AmazonSESTest.php
@@ -3,12 +3,10 @@
 namespace Omnimail\Tests;
 
 use Omnimail\Exception\Exception;
-use PHPUnit_Framework_TestCase;
 use Omnimail\Email;
 use Omnimail\AmazonSES;
-use PHPUnit\Framework\TestCase;
 
-class AmazonSESTest extends TestCase
+class AmazonSESTest extends BaseTestClass
 {
     public function testErrorMessageIsThrownWithIncorrectDetails()
     {

--- a/test/tests/AttachmentTest.php
+++ b/test/tests/AttachmentTest.php
@@ -4,9 +4,8 @@ namespace Omnimail\Tests;
 
 use Omnimail\Attachment;
 use Omnimail\AttachmentInterface;
-use PHPUnit\Framework\TestCase;
 
-class AttachmentTest extends TestCase
+class AttachmentTest extends BaseTestClass
 {
     public function testToArray()
     {

--- a/test/tests/BaseTestClass.php
+++ b/test/tests/BaseTestClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Omnimail\Tests;
+
+use Omnimail\Omnimail;
+use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+
+class BaseTestClass extends TestCase
+{
+}

--- a/test/tests/EmailTest.php
+++ b/test/tests/EmailTest.php
@@ -3,9 +3,8 @@
 namespace Omnimail\Tests;
 
 use Omnimail\Email;
-use PHPUnit\Framework\TestCase;
 
-class EmailTest extends TestCase
+class EmailTest extends BaseTestClass
 {
     public function testToArray()
     {

--- a/test/tests/MailgunTest.php
+++ b/test/tests/MailgunTest.php
@@ -3,14 +3,13 @@
 namespace Omnimail\Tests;
 
 use Omnimail\Exception\Exception;
-use PHPUnit\Framework\TestCase;
 use Omnimail\Email;
 use Omnimail\Tests\Mock\Mailgun;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 
-class MailgunTest extends TestCase
+class MailgunTest extends BaseTestClass
 {
     public function testRequestIsGeneratedCorrectly()
     {

--- a/test/tests/MailjetTest.php
+++ b/test/tests/MailjetTest.php
@@ -3,11 +3,10 @@
 namespace Omnimail\Tests;
 
 use Omnimail\Exception\Exception;
-use PHPUnit\Framework\TestCase;
 use Omnimail\Email;
 use Omnimail\Mailjet;
 
-class MailjetTest extends TestCase
+class MailjetTest extends BaseTestClass
 {
     public function testErrorMessageIsThrownWithIncorrectDetails()
     {

--- a/test/tests/MandrillTest.php
+++ b/test/tests/MandrillTest.php
@@ -3,11 +3,10 @@
 namespace Omnimail\Tests;
 
 use Omnimail\Exception\Exception;
-use PHPUnit\Framework\TestCase;
 use Omnimail\Email;
 use Omnimail\Mandrill;
 
-class MandrillTest extends TestCase
+class MandrillTest extends BaseTestClass
 {
     public function testErrorMessageIsThrownWithIncorrectDetails()
     {

--- a/test/tests/PostmarkTest.php
+++ b/test/tests/PostmarkTest.php
@@ -3,11 +3,10 @@
 namespace Omnimail\Tests;
 
 use Omnimail\Exception\Exception;
-use PHPUnit\Framework\TestCase;
 use Omnimail\Email;
 use Omnimail\Postmark;
 
-class PostmarkTest extends TestCase
+class PostmarkTest extends BaseTestClass
 {
     public function testErrorMessageIsThrownWithIncorrectDetails()
     {

--- a/test/tests/SendgridTest.php
+++ b/test/tests/SendgridTest.php
@@ -2,12 +2,11 @@
 
 namespace Omnimail\Tests;
 
-use Omnimail\Exception\Exception;
-use PHPUnit\Framework\TestCase;
 use Omnimail\Email;
 use Omnimail\Sendgrid;
+use Omnimail\Exception\Exception;
 
-class SendgridTest extends TestCase
+class SendgridTest extends BaseTestClass
 {
     public function testErrorMessageIsThrownWithIncorrectDetails()
     {

--- a/test/tests/SendinBlueTest.php
+++ b/test/tests/SendinBlueTest.php
@@ -3,11 +3,10 @@
 namespace Omnimail\Tests;
 
 use Omnimail\Exception\Exception;
-use PHPUnit\Framework\TestCase;
 use Omnimail\Email;
 use Omnimail\SendinBlue;
 
-class SendinBlueTest extends TestCase
+class SendinBlueTest extends BaseTestClass
 {
     public function testErrorMessageIsThrownWithIncorrectDetails()
     {

--- a/test/tests/Utils/TokenTest.php
+++ b/test/tests/Utils/TokenTest.php
@@ -2,10 +2,10 @@
 
 namespace Omnimail\Tests\Utils;
 
-use PHPUnit\Framework\TestCase;
 use Omnimail\Utils\Token;
+use Omnimail\Tests\BaseTestClass;
 
-class TokenTest extends TestCase
+class TokenTest extends BaseTestClass
 {
     public function testTokenGeneration()
     {


### PR DESCRIPTION
From the recent upgrade to php 7 I can see that every file had to be changed to reflect the
phpunit version. By extending a class we can put that change in one place.

I'm actually working on php 5.6 so this allows me to run the tests on that
version with a low level of tinkering