### PR TITLE
Switch to using annotation for expectedException.

### DIFF
--- a/test/tests/BaseTestClass.php
+++ b/test/tests/BaseTestClass.php
@@ -9,6 +9,14 @@ use PHPUnit\Framework\TestCase;
 if (class_exists('\PHPUnit\Framework\TestCase')) {
     class BaseTestClass extends TestCase
     {
+        public function expectException($exception)
+        {
+            if (is_callable('parent::expectException')) {
+                parent::expectException($exception);
+            } else {
+                $this->setExpectedException($exception);
+            }
+        }
     }
 } elseif (class_exists('\PHPUnit_Framework_TestCase')) {
     class BaseTestClass extends PHPUnit_Framework_TestCase


### PR DESCRIPTION
The annotation works on multiple php versions whereas the expectedException function
is only php 6. In order to re-enable tests on earlier php we need to switch to this