### PR TITLE
Fix tests to work across versions by altering composer command.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
 before_script:
   ## Composer
   - composer self-update
-  - composer install --prefer-source --no-interaction --dev --ignore-platform-reqs
+  - composer install --prefer-source --no-interaction --dev
 
 script: phpunit
 
@@ -20,6 +20,5 @@ matrix:
     - php: nightly
     - php: hhvm
     - php: 5.5
-    - php: 5.6
 
 sudo: false

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "paragonie/random_compat": "^2.0"
     },
     "require-dev" : {
-        "phpunit/phpunit": "^5.7 || ^6.1",
+        "phpunit/phpunit": "~4.4 || ^6.1",
         "wildbit/postmark-php": "^2.3",
         "sendgrid/sendgrid": "^5.5",
         "mailin-api/mailin-api-php": "^1.0",


### PR DESCRIPTION
I tinkered a bit to see if I could get 5.6 tests working & into the CI build and these changes worked for me with travis

(some info here but mostly I just tried it to see if it would work....
https://stackoverflow.com/questions/35273522/how-to-always-use-ignore-platform-reqs-flag-when-running-composer)