### PR TITLE
Fix Mandrill class's subject and response problems

### DIFF
--- a/src/Mandrill.php
+++ b/src/Mandrill.php
@@ -64,7 +64,7 @@ class Mandrill implements MailerInterface
             $from = $email->getFrom();
 
             $message = [
-                'subject' => 'example subject',
+                'subject' => $email->getSubject(),
                 'from_email' => $from['email'],
                 'to' => $this->mapEmails($email->getTos())
             ];
@@ -107,6 +107,7 @@ class Mandrill implements MailerInterface
             }
 
             $result = $this->mandrill->messages->send($message, false, $this->ipPool);
+            $result = current($result);
             if ($result && $result['status'] &&
                 ($result['status'] === 'sent' || $result['status'] === 'queued' || $result['status'] === 'scheduled')
             ) {


### PR DESCRIPTION
1. Change subject of the mail sent
2. Mandrill SDK returns an array on send action, so fix the result checks