### PR TITLE
Change AmazonSES to default to v4 signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ composer require omnimail/omnimail
 To use the AmazonSES mailer class, you will need to install the `daniel-zahariev/php-aws-ses` library using composer.
 
 ```
-composer require daniel-zahariev/php-aws-ses
+composer require "daniel-zahariev/php-aws-ses:^0.9.2"
 ```
 
 #### Usage
@@ -76,7 +76,7 @@ composer require daniel-zahariev/php-aws-ses
 use Omnimail\Email;
 use Omnimail\AmazonSES;
 
-$mailer = new AmazonSES($accessKey, $secretKey, $region, $verifyPeer, $verifyHost);
+$mailer = new AmazonSES($accessKey, $secretKey, $region, $verifyPeer, $verifyHost, $signatureVersion);
 
 $email = (new Email())
     ->addTo('example@email.com')

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/log" : "^1.0"
     },
     "require-dev" : {
-        "daniel-zahariev/php-aws-ses": "^0.9",
+        "daniel-zahariev/php-aws-ses": "^0.9.2",
         "mailgun/mailgun-php": "^2.4",
         "mailin-api/mailin-api-php": "^1.0",
         "mailjet/mailjet-apiv3-php": "^1.2",

--- a/src/AmazonSES.php
+++ b/src/AmazonSES.php
@@ -20,6 +20,7 @@ class AmazonSES extends AbstractMailer implements MailerInterface
     protected $logger;
     protected $verifyPeer;
     protected $verifyHost;
+    protected $signatureVersion;
 
     /**
      * @return null|string
@@ -118,6 +119,14 @@ class AmazonSES extends AbstractMailer implements MailerInterface
     }
 
     /**
+     * @param boolean $signatureVersion
+     */
+    public function setSignatureVersion($signatureVersion)
+    {
+        $this->signatureVersion = $signatureVersion;
+    }
+
+    /**
      * @param string $accessKey
      * @param string $secretKey
      * @param string $host
@@ -125,7 +134,7 @@ class AmazonSES extends AbstractMailer implements MailerInterface
      * @param bool $verifyHost
      * @param LoggerInterface|null $logger
      */
-    public function __construct($accessKey = null, $secretKey = null, $host = self::AWS_US_EAST_1, $verifyPeer = true, $verifyHost = true, LoggerInterface $logger = null)
+    public function __construct($accessKey = null, $secretKey = null, $host = self::AWS_US_EAST_1, $verifyPeer = true, $verifyHost = true, LoggerInterface $logger = null, string $signatureVersion = SimpleEmailService::REQUEST_SIGNATURE_V4)
     {
         $this->verifyPeer = $verifyPeer;
         $this->verifyHost = $verifyHost;
@@ -133,6 +142,7 @@ class AmazonSES extends AbstractMailer implements MailerInterface
         $this->secretKey = $secretKey;
         $this->host = $host;
         $this->logger = $logger;
+        $this->signatureVersion = $signatureVersion;
     }
 
     public function send(EmailInterface $email)
@@ -178,7 +188,7 @@ class AmazonSES extends AbstractMailer implements MailerInterface
             }
         }
 
-        $ses = new SimpleEmailService($this->accessKey, $this->secretKey, $this->host, false);
+        $ses = new SimpleEmailService($this->accessKey, $this->secretKey, $this->host, false, $this->signatureVersion);
         $ses->setVerifyPeer($this->verifyPeer);
         $ses->setVerifyHost($this->verifyHost);
         $response = $ses->sendEmail($m, false, false);


### PR DESCRIPTION
Issue #39 

Allow use of different signature versions for AmazonSES
Default to v4 AmazonSES signature (v3 is going away)