### PR TITLE
Remove required for abandoned php5.x package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "require" : {
         "php" : ">=7.0",
         "ext-json": "*",
-        "paragonie/random_compat": "^2.0",
         "php-http/httplug": "^1.1|2.*",
         "psr/log": "^1.1"
     },


### PR DESCRIPTION
https://github.com/paragonie/random_compat is abandoned & no longer required as php 5.x is very old now....

It would be great to get this tagged as there are other composer.json updates not in the tagged release