### PR TITLE
Address deprecation warning

### DIFF
--- a/src/Common/Helper.php
+++ b/src/Common/Helper.php
@@ -68,7 +68,7 @@ class Helper
         if (!class_exists($fullyQualified)) {
             $fullyQualified = $fullyQualified . '\\Mailer';
             if (!class_exists($fullyQualified)) {
-                throw new Exception("Class '${className}' not found");
+                throw new Exception("Class '{$className}' not found");
             }
         }
 


### PR DESCRIPTION
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead